### PR TITLE
Revert "Update Helm chart grocy to v6 [ci-skip]"

### DIFF
--- a/main/homelab/grocy/Chart.yaml
+++ b/main/homelab/grocy/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 version: 1.0.0
 dependencies:
   - name: grocy
-    version: "6.0.0"
+    version: "5.1.1"
     repository: https://k8s-at-home.com/charts/


### PR DESCRIPTION
Reverts rogerrum/k8s-gitops#65